### PR TITLE
New fabric

### DIFF
--- a/src/design/design.py
+++ b/src/design/design.py
@@ -19,7 +19,7 @@ class Design(NamedIDObject):
     @property
     def nets(self):
         return self._nets
-    
+
 
     def _gen_graph(self, adj_dict, op_dict):
         mods = dict()
@@ -30,8 +30,8 @@ class Design(NamedIDObject):
                 self._modules.add(src)
             else:
                 src = mods[src_name]
-            
-            
+
+
             for dst_name, dst_port, width in adj_list:
                 if dst_name not in mods:
                     dst = Module(dst_name, *op_dict[dst_name])

--- a/src/fabric/fabric.py
+++ b/src/fabric/fabric.py
@@ -254,7 +254,7 @@ def connect_pe(root, BUS, params):
                     for src in mux.findall('src'):
                         port_name = src.text
                         direc, bus, side, track = parse_name(port_name)
-                        srcport = SB[(x, y, side, direc)]
+                        srcport = SB[(x, y, side, direc)][track]
                         dstport = PE[(x, y, snk)]  # same port that was created above
                         wire_names = (port_name, snk)
                         tracks.append(Track(srcport, dstport, wire_names, 'CB'))

--- a/src/fabric/fabric.py
+++ b/src/fabric/fabric.py
@@ -24,6 +24,10 @@ class Port(IDObject):
     def loc(self):
         return (self._x, self._y)
 
+    @property
+    def __repr__(self):
+        return str(self.loc) + 'port'
+
 
 class Track(IDObject):
     '''
@@ -58,12 +62,13 @@ class Track(IDObject):
 
 
 class Fabric:
-    def __init__(self, rows, cols, sources, sinks, routable):
+    def __init__(self, rows, cols, sources, sinks, routable, tracks):
         self._rows = rows
         self._cols = cols
         self._sources = sources
         self._sinks = sinks
         self._routable = routable
+        self._tracks = tracks
 
     @property
     def rows(self):
@@ -71,6 +76,16 @@ class Fabric:
 
     @property
     def cols(self):
+        return self._cols
+
+    @property
+    def height(self):
+        ''' alias for rows'''
+        return self._rows
+
+    @property
+    def width(self):
+        ''' alias for cols'''
         return self._cols
 
     @property
@@ -84,6 +99,10 @@ class Fabric:
     @property
     def routable(self):
         return self._routable
+
+    @property
+    def tracks(self):
+        return self._tracks
 
 
 def parse_xml(filepath):
@@ -113,7 +132,7 @@ def parse_xml(filepath):
 
     connect_sb(root, 'BUS16', params)
 
-    return Fabric(rows, cols, params['sourcesBUS16'], params['sinksBUS16'], params['routableBUS16'])
+    return Fabric(rows, cols, params['sourcesBUS16'], params['sinksBUS16'], params['routableBUS16'], params['tracksBUS16'])
 
 
 def pre_process(root):
@@ -129,14 +148,15 @@ def pre_process(root):
             rows = r
         if c > cols:
             cols = c
-        tracks = tile.get('tracks').split
+        tracks = tile.get('tracks').split()
         for track in tracks:
             tr = track.split(':')
             # still indexing as x, y for now
             # i.e. col, row
-            num_tracks[(c, r, tr[0])] = tr[1]
+            num_tracks[(c, r, tr[0])] = int(tr[1])
 
-    return rows, cols, num_tracks
+    # rows and cols are the number not the index
+    return rows + 1, cols + 1, num_tracks
 
 
 def generate_layer(BUS, params):
@@ -154,21 +174,21 @@ def generate_layer(BUS, params):
     # add inputs from the edges as sources
     for y in range(0, params['rows']):
         # for x = 0 and all y
-        for t in params['num_tracks'][(0, y, BUS)]:
+        for t in range(0, params['num_tracks'][(0, y, BUS)]):
             sources[(0, y, t)] = SB[(0, y, Side.W, 'in')]
 
-        # for x = cols and all y
-        for t in params['num_tracks'][(params['cols'], y, BUS)]:
-            sources[(params['cols'], y, t)] = SB[(params['cols'], y, Side.E, 'in')]
+        # for x = cols-1 and all y
+        for t in range(0, params['num_tracks'][(params['cols'] - 1, y, BUS)]):
+            sources[(params['cols'], y, t)] = SB[(params['cols'] - 1, y, Side.E, 'in')]
 
     for x in range(0, params['cols']):
         # for y = 0 and all x
-        for t in params['num_tracks'][(x, 0, BUS)]:
+        for t in range(0, params['num_tracks'][(x, 0, BUS)]):
             sources[(x, 0, t)] = SB[(x, 0, Side.N, 'in')]
 
-        # for y = rows and all x
-        for t in params['num_tracks'][(x, params['rows'], BUS)]:
-            sources[(x, params['rows'], t)] = SB[(x, params['rows'], Side.S, 'in')]
+        # for y = rows-1 and all x
+        for t in range(0, params['num_tracks'][(x, params['rows'] - 1, BUS)]):
+            sources[(x, params['rows'], t)] = SB[(x, params['rows'] - 1, Side.S, 'in')]
 
     return SB, PE
 
@@ -201,7 +221,7 @@ def connect_tiles(BUS, params):
                 # otherwise make ports for off the edge
                 else:
                     ports = []
-                    for t in num_tracks[(x, y, BUS)]:
+                    for t in range(0, num_tracks[(x, y, BUS)]):
                         p = Port(x, y)
                         ports.append(p)
                         sinks[(x, y, t)] = p
@@ -232,7 +252,7 @@ def connect_pe(root, BUS, params):
                     PE[(x, y, snk)] = port
                     sinks[(x, y, snk)] = port
                     for src in mux.findall('src'):
-                        port_name = src.txt
+                        port_name = src.text
                         direc, bus, side, track = parse_name(port_name)
                         srcport = SB[(x, y, side, direc)]
                         dstport = PE[(x, y, snk)]  # same port that was created above
@@ -245,7 +265,7 @@ def connect_pe(root, BUS, params):
 def connect_sb(root, BUS, params):
     SB = params['SB' + BUS]
     PE = params['PE' + BUS]
-    tracks = params['tracks']
+    tracks = params['tracks' + BUS]
     for tile in root:
         x = int(tile.get('row'))
         y = int(tile.get('col'))

--- a/src/fabric/fabricfuns.py
+++ b/src/fabric/fabricfuns.py
@@ -8,7 +8,7 @@ class Side(Enum):
     S = 1
     E = 0
     W = 2
-    NS = 4 #no side
+    PE = 4 #no side
 
 def getSide(side_str):
     '''

--- a/src/pnr/backends.py
+++ b/src/pnr/backends.py
@@ -10,7 +10,7 @@ from fabric.fabricfuns import parse_name, mapSide
 from fabric import Side
 from util import smart_open
 
-__all__ = ['write_debug', 'write_bitstream', 'write_xml']
+__all__ = ['write_debug', 'write_route_debug', 'write_bitstream', 'write_xml']
 
 # -------------------------------------------------
 # write_bitsream consants 
@@ -172,6 +172,22 @@ def _write_debug(design, output, p_state, r_state):
         for net in design.nets:
             f.write("{} -> {}\n".format(net.src.name, net.dst.name))
         f.write("\n")
+
+def write_route_debug(design, output=sys.stdout):
+    return partial(_write_route_debug, design, output)
+
+def _write_route_debug(design, output, p_state, r_state):
+    '''
+       Debug printer four routing
+       Nodes are currently named with the wire names from input file
+       which is unfortunately verbose...
+    '''
+    with smart_open(output) as f:
+        for net in design.nets:
+            f.write('{} -> {}:\n'.format(net.src.name, net.dst.name))
+            f.write(str(r_state[(net, 'debug')]))
+            f.write("\n")
+
 
 def write_xml(inpath, outpath, io_outpath):
     return partial(_write_xml, inpath, outpath, io_outpath)

--- a/src/pnr/constraints.py
+++ b/src/pnr/constraints.py
@@ -179,13 +179,11 @@ def build_msgraph(fabric, design, p_state, r_state, vars, solver):
     for track in fabric.tracks:
         src = track.src
         dst = track.dst
-        src_name = track.wire_names[0]
-        dst_name = track.wire_names[1]
-        # naming scheme is (row, col)wire_name
+        # naming scheme is (x, y)Side_direction[track]
         if src not in vars:
-            vars[src] = graph.addNode(str((y, x)) + src_name)
+            vars[src] = graph.addNode(src.name)
         if dst not in vars:
-            vars[dst] = graph.addNode(str((y, x)) + dst_name)
+            vars[dst] = graph.addNode(dst.name)
 
         # create a monosat edge
         e = graph.addEdge(vars[src], vars[dst])
@@ -233,18 +231,15 @@ def build_net_graphs(fabric, design, p_state, r_state, vars, solver):
         src = track.src
         dst = track.dst
 
-        src_name = track.wire_names[0]
-        dst_name = track.wire_names[1]
-        
-        # naming scheme is (row, col)wire_name
+        # naming scheme is (x, y)Side_direction[track]
         if src not in vars:
             for net in design.nets:
-                u = vars[net].addNode(str((y, x)) + src_name)
+                u = vars[net].addNode(src.name)
                 node_dict[net][u] = solver.false()
             vars[src] = u
         if dst not in vars:
             for net in design.nets:
-                v = vars[net].addNode(str((y, x)) + dst_name)
+                v = vars[net].addNode(dst.name)
                 node_dict[net][v] = solver.false()
             vars[dst] = v
 

--- a/src/pnr/constraints.py
+++ b/src/pnr/constraints.py
@@ -200,6 +200,9 @@ def build_net_graphs(fabric, design, p_state, r_state, vars, solver):
         Handles exclusivity constraints inherently
     '''
 
+    # NOTE: Currently broken for fanout
+    # Making nets contain whole tree of connections will fix this issue
+
     # create graphs for each net
     node_dict = dict()  # used to keep track of nodes in each graph
     for net in design.nets:

--- a/src/pnr/constraints.py
+++ b/src/pnr/constraints.py
@@ -77,6 +77,9 @@ def excl_constraints(fabric, design, p_state, r_state, vars, solver):
     # TODO: don't hardcode these -- get from coreir?
     ports = {'a', 'b'}
 
+    sources = fabric.sources
+    sinks = fabric.sinks
+
     # for connected modules, make sure it's not connected to wrong inputs
     # TODO: Fix this so doesn't assume only connected to one input port
     # there might be weird cases where you want to drive multiple inputs
@@ -84,24 +87,20 @@ def excl_constraints(fabric, design, p_state, r_state, vars, solver):
     for net in design.nets:
         src_pos = p_state[net.src][0]
         dst_pos = p_state[net.dst][0]
-        src_pe = fabric[src_pos].PE
-        dst_pe = fabric[dst_pos].PE
 
         for port in ports - set(net.dst_port):
-            c.append(~vars[net].reaches(vars[src_pe.getPort(net.src_port)], vars[dst_pe.getPort(port)]))
+            c.append(~vars[net].reaches(vars[sources[src_pos + (net.src_port,)]], vars[sinks[dst_pos + (port,)]]))
 
     # make sure modules that aren't connected are not connected
     for m1 in design.modules:
         inputs = {x.src for x in m1.inputs}
         m1_pos = p_state[m1][0]
-        pe_dst = fabric[m1_pos].PE
         for m2 in design.modules:
             if m2 != m1 and m2 not in inputs:
                 m2_pos = p_state[m2][0]
-                pe_src = fabric[m2_pos].PE
 
                 for port in ports:
-                    c.append(~graph.reaches(vars[pe_src.getPort('out')], vars[pe_dst.getPort(port)]))
+                    c.append(~graph.reaches(vars[sources[m2_pos + ('out',)]], vars[sinks[m1_pos + (port,)]]))
 
     return solver.And(c)
 
@@ -112,12 +111,14 @@ def reachability(fabric, design, p_state, r_state, vars, solver):
         Works with build_msgraph, excl_constraints and dist_limit
     '''
     reaches = []
+    sources = fabric.sources
+    sinks = fabric.sinks
     for net in design.nets:
         src_pos = p_state[net.src][0]
         dst_pos = p_state[net.dst][0]
-        src_pe = fabric[src_pos].PE
-        dst_pe = fabric[dst_pos].PE
-        reaches.append(vars[net].reaches(vars[src_pe.getPort(net.src_port)], vars[dst_pe.getPort(net.dst_port)]))
+        src_pe = sources[src_pos + (net.src_port,)]
+        dst_pe = sinks[dst_pos + (net.dst_port,)]
+        reaches.append(vars[net].reaches(vars[src_pe], vars[dst_pe]))
 
     return solver.And(reaches)
 
@@ -133,20 +134,22 @@ def dist_limit(dist_factor):
 
     def dist_constraints(fabric, design, p_state, r_state, vars, solver):
         constraints = []
+        sources = fabric.sources
+        sinks = fabric.sinks
         for net in design.nets:
             src_pos = p_state[net.src][0]
             dst_pos = p_state[net.dst][0]
-            src_pe = fabric[src_pos].PE
-            dst_pe = fabric[dst_pos].PE 
+            src_pe = sources[src_pos + (net.src_port,)]
+            dst_pe = sinks[dst_pos + (net.dst_port,)]
             manhattan_dist = int(abs(src_pos[0] - dst_pos[0]) + abs(src_pos[1] - dst_pos[1]))
             # This is just a weird heuristic for now. We have to have at least 2*manhattan_dist because
             # for each jump it needs to go through a port. So 1 in manhattan distance is 2 in monosat distance
             # Additionally, because the way ports are connected (i.e. only accessible from horizontal or vertical tracks)
             # It often happens that a routing is UNSAT for just 2*manhattan_dist so instead we use a factor of 3 and add 1
             # You can adjust it with dist_factor
-            constraints.append(vars[net].distance_leq(vars[src_pe.getPort(net.src_port)],
-                                                     vars[dst_pe.getPort(net.dst_port)],
-                                                     3*dist_factor*manhattan_dist + 1))
+            constraints.append(vars[net].distance_leq(vars[src_pe],
+                                                      vars[dst_pe],
+                                                      3*dist_factor*manhattan_dist + 1))
         return solver.And(constraints)
     return dist_constraints
 
@@ -161,26 +164,32 @@ def build_msgraph(fabric, design, p_state, r_state, vars, solver):
 
     graph = solver.graphs[0]  # only one graph in this encoding
 
+    sources = fabric.sources
+    sinks = fabric.sinks
+
     # add msnodes for all the used PEs first (because special naming scheme)
+    # Hacky! Hardcoding port names
     for x in range(fabric.width):
         for y in range(fabric.height):
             if (x, y) in p_state.I:
-                vars[fabric[(x, y)].PE.getPort('a')] = graph.addNode('({},{})PE_a'.format(x, y))
-                vars[fabric[(x, y)].PE.getPort('b')] = graph.addNode('({},{})PE_b'.format(x, y))
-                vars[fabric[(x, y)].PE.getPort('out')] = graph.addNode('({},{})PE_out'.format(x, y))
+                vars[sinks[(x, y, 'a')]] = graph.addNode('({},{})PE_a'.format(x, y))
+                vars[sinks[(x, y, 'b')]] = graph.addNode('({},{})PE_b'.format(x, y))
+                vars[sources[(x, y, 'out')]] = graph.addNode('({},{})PE_out'.format(x, y))
 
-    for tile in fabric.Tiles.values():
-        for track in tile.tracks:
-            src = track.src
-            dst = track.dst
-            if src not in vars:
-                vars[src] = graph.addNode('({},{}){}_i[{}]'.format(str(src.x), str(src.y), src.side.name, str(src.track)))
-            if dst not in vars:
-                vars[dst] = graph.addNode('({},{}){}_i[{}]'.format(str(dst.x), str(dst.y), dst.side.name, str(dst.track)))
+    for track in fabric.tracks:
+        src = track.src
+        dst = track.dst
+        src_name = track.wire_names[0]
+        dst_name = track.wire_names[1]
+        # naming scheme is (row, col)wire_name
+        if src not in vars:
+            vars[src] = graph.addNode(str((y, x)) + src_name)
+        if dst not in vars:
+            vars[dst] = graph.addNode(str((y, x)) + dst_name)
 
-            # create a monosat edge
-            e = graph.addEdge(vars[src], vars[dst])
-            vars[e] = track  # we need to recover the track in model_reader
+        # create a monosat edge
+        e = graph.addEdge(vars[src], vars[dst])
+        vars[e] = track  # we need to recover the track in model_reader
 
     return solver.And([])
 
@@ -197,47 +206,54 @@ def build_net_graphs(fabric, design, p_state, r_state, vars, solver):
         vars[net] = solver.add_graph()
         node_dict[net] = dict()
 
+    sources = fabric.sources
+    sinks = fabric.sinks
+
     # add msnodes for all the used PEs first (because special naming scheme)
     for x in range(fabric.width):
         for y in range(fabric.height):
             if (x, y) in p_state.I:
                 for net in design.nets:
-                    a = vars[net].addNode('({},{})PE_a'.format(x, y))
-                    b = vars[net].addNode('({},{})PE_b'.format(x, y))
-                    out = vars[net].addNode('({},{})PE_out'.format(x, y))
+                    a = vars[net].addNode('({},{})PE_a'.format(y, x))
+                    b = vars[net].addNode('({},{})PE_b'.format(y, x))
+                    out = vars[net].addNode('({},{})PE_out'.format(y, x))
                     node_dict[net][a] = solver.false()
                     node_dict[net][b] = solver.false()
                     node_dict[net][out] = solver.false()
                 # add each node to vars as well
                 # only need to add it once (not for each net/graph)
-                vars[fabric[(x, y)].PE.getPort('a')] = a
-                vars[fabric[(x, y)].PE.getPort('b')] = b
-                vars[fabric[(x, y)].PE.getPort('out')] = out 
+                vars[sinks[(x, y, 'a')]] = a
+                vars[sinks[(x, y, 'b')]] = b
+                vars[sources[(x, y, 'out')]] = out
 
-    for tile in fabric.Tiles.values(): 
-        for track in tile.tracks:
-            src = track.src
-            dst = track.dst
+    for track in fabric.tracks:
+        src = track.src
+        dst = track.dst
 
-            if src not in vars:
-                for net in design.nets:
-                    u = vars[net].addNode('({},{}){}_i[{}]'.format(str(src.x), str(src.y), src.side.name, str(src.track)))
-                    node_dict[net][u] = solver.false()
-                vars[src] = u
-            if dst not in vars:
-                for net in design.nets:
-                    v = vars[net].addNode('({},{}){}_i[{}]'.format(str(dst.x), str(dst.y), dst.side.name, str(dst.track)))
-                    node_dict[net][v] = solver.false()
-                vars[dst] = v
-
+        src_name = track.wire_names[0]
+        dst_name = track.wire_names[1]
+        
+        # naming scheme is (row, col)wire_name
+        if src not in vars:
             for net in design.nets:
-                e = vars[net].addEdge(vars[src], vars[dst])
-                node_dict[net][vars[src]] = solver.Or(node_dict[net][vars[src]], e)
-                node_dict[net][vars[dst]] = solver.Or(node_dict[net][vars[dst]], e)
-                # put in r_state because we need to map track to multiple edges
-                # i.e. need BiMultiDict
-                # Plus, we only use this in model_reader so it makes sense to have in r_state
-                vars[e] = track
+                u = vars[net].addNode(str((y, x)) + src_name)
+                node_dict[net][u] = solver.false()
+            vars[src] = u
+        if dst not in vars:
+            for net in design.nets:
+                v = vars[net].addNode(str((y, x)) + dst_name)
+                node_dict[net][v] = solver.false()
+            vars[dst] = v
+
+        # keep track of whether a node is 'active' based on connected edges
+        for net in design.nets:
+            e = vars[net].addEdge(vars[src], vars[dst])
+            node_dict[net][vars[src]] = solver.Or(node_dict[net][vars[src]], e)
+            node_dict[net][vars[dst]] = solver.Or(node_dict[net][vars[dst]], e)
+            # put in r_state because we need to map track to multiple edges
+            # i.e. need BiMultiDict
+            # Plus, we only use this in model_reader so it makes sense to have in r_state
+            vars[e] = track
 
     # now enforce that each node is only used in one of the graphs
     # Note: all graphs have same nodes, so can get them from any graph

--- a/src/pnr/model_readers.py
+++ b/src/pnr/model_readers.py
@@ -26,7 +26,7 @@ def route_model_reader(fabric, design, p_state, r_state, vars, solver):
             edge = graph.getEdge(n1, n2)
             track = vars[edge]
             src_port = track.src
-            outname = track.wire_names[1]
-            inname = track.wire_names[0]
+            outname = track.track_names[1]
+            inname = track.track_names[0]
             state = (src_port.x, src_port.y, track.parent, outname, inname)
             r_state[net] = state

--- a/src/pnr/model_readers.py
+++ b/src/pnr/model_readers.py
@@ -10,7 +10,7 @@ def route_model_reader(fabric, design, p_state, r_state, vars, solver):
         src = net.src
         dst = net.dst
         graph = vars[net]
-        
+
         src_pos = p_state[src][0]
         dst_pos = p_state[dst][0]
         src_pe = fabric[src_pos].PE

--- a/src/test.py
+++ b/src/test.py
@@ -12,6 +12,7 @@ parser.add_argument('--xml', nargs=2, metavar=('<PLACEMENT_FILE>', '<IO_FILE>'),
 parser.add_argument('--bitstream', metavar='<BITSTREAM_FILE>', 
         help='output CGRA configuration in bitstream')
 parser.add_argument('--print', action='store_true', help='print CGRA configuration to stdout')
+parser.add_argument('--print_route', action='store_true', help='print routing information to stdout')
 args = parser.parse_args()
 
 df = args.df
@@ -21,9 +22,9 @@ ff = args.ff
 POSITION_T = partial(smt.BVXY, solver=pnr.PLACE_SOLVER)
 PLACE_CONSTRAINTS = pnr.init_positions(POSITION_T), pnr.distinct, pnr.nearest_neighbor, pnr.pin_IO
 PLACE_RELAXED =  pnr.init_positions(POSITION_T), pnr.distinct, pnr.pin_IO
-ROUTE_CONSTRAINTS = pnr.build_msgraph, pnr.excl_constraints, pnr.reachability, pnr.dist_limit(1)
+# ROUTE_CONSTRAINTS = pnr.build_msgraph, pnr.excl_constraints, pnr.reachability, pnr.dist_limit(1)
 # To use multigraph encoding:
-# ROUTE_CONSTRAINTS = pnr.build_net_graphs, pnr.reachability, pnr.dist_limit(1)
+ROUTE_CONSTRAINTS = pnr.build_net_graphs, pnr.reachability, pnr.dist_limit(1)
 
 print("Loading design: {}".format(df))
 d = design.Design(*design.core2graph.load_core(df))
@@ -66,3 +67,6 @@ if args.print:
     print("\nPlacement info:")
     p.write_design(pnr.write_debug(d))
 
+if args.print_route:
+    print("\nRouting info:")
+    p.write_design(pnr.write_route_debug(d))

--- a/src/test.py
+++ b/src/test.py
@@ -29,7 +29,7 @@ print("Loading design: {}".format(df))
 d = design.Design(*design.core2graph.load_core(df))
 
 print("Loading fabric: {}".format(ff))
-f = fabric.parseXML(ff)
+f = fabric.parse_xml(ff)
 
 p = pnr.PNR(f, d)
 

--- a/src/test.py
+++ b/src/test.py
@@ -22,9 +22,11 @@ ff = args.ff
 POSITION_T = partial(smt.BVXY, solver=pnr.PLACE_SOLVER)
 PLACE_CONSTRAINTS = pnr.init_positions(POSITION_T), pnr.distinct, pnr.nearest_neighbor, pnr.pin_IO
 PLACE_RELAXED =  pnr.init_positions(POSITION_T), pnr.distinct, pnr.pin_IO
-# ROUTE_CONSTRAINTS = pnr.build_msgraph, pnr.excl_constraints, pnr.reachability, pnr.dist_limit(1)
+ROUTE_CONSTRAINTS = pnr.build_msgraph, pnr.excl_constraints, pnr.reachability, pnr.dist_limit(1)
 # To use multigraph encoding:
-ROUTE_CONSTRAINTS = pnr.build_net_graphs, pnr.reachability, pnr.dist_limit(1)
+# Note: This encoding does not handle fanout for now
+# Once nets represent the whole tree of connections, this will be fixed
+# ROUTE_CONSTRAINTS = pnr.build_net_graphs, pnr.reachability, pnr.dist_limit(1)
 
 print("Loading design: {}".format(df))
 d = design.Design(*design.core2graph.load_core(df))


### PR DESCRIPTION
Rewrote the fabric. Added routing debug prints. They currently use the wire names which are a little lengthy -- I'll fix that soon.

Note: The multi-graph routing encoding is currently broken for fanout (this is also true on master). This is because each net gets its own graph and nodes are asserted to only be "enabled" in one of the graphs. However since nets can share source nodes, this makes the problem infeasible if there's any fanout. Once nets represent trees of connections this problem will be fixed inherently.