### PR TITLE
Fab layers

### DIFF
--- a/src/fabric/fabric.py
+++ b/src/fabric/fabric.py
@@ -75,33 +75,8 @@ class Track(NamedIDObject):
 #        return '{} --> {}'.format(self._names[0], self._names[1])
 
 
-class FabricDims(metaclass=ABCMeta):
-    def __init__(self, rows, cols):
-        self._rows = rows
-        self._cols = cols
-
-    @property
-    def rows(self):
-        return self._rows
-
-    @property
-    def cols(self):
-        return self._cols
-
-    @property
-    def height(self):
-        ''' alias for rows'''
-        return self._rows
-
-    @property
-    def width(self):
-        ''' alias for cols'''
-        return self._cols
-
-
-class FabricLayer(FabricDims):
-    def __init__(self, rows, cols, sources, sinks, routable, tracks):
-        super().__init__(rows, cols)
+class FabricLayer:
+    def __init__(self, sources, sinks, routable, tracks):
         self._sources = sources
         self._sinks = sinks
         self._routable = routable
@@ -124,17 +99,35 @@ class FabricLayer(FabricDims):
         return self._tracks
 
 
-class Fabric(FabricDims):
+class Fabric:
     def __init__(self, parsed_params):
-        super().__init__(parsed_params['rows'], parsed_params['cols'])
+        self._rows = parsed_params['rows']
+        self._cols = parsed_params['cols']
         self._layers = dict()
         for bus_width in parsed_params['bus_widths']:
-            fl = FabricLayer(self.rows, self.cols,
-                             parsed_params['sources' + bus_width],
+            fl = FabricLayer(parsed_params['sources' + bus_width],
                              parsed_params['sinks' + bus_width],
                              parsed_params['routable' + bus_width],
                              parsed_params['tracks' + bus_width])
             self._layers[int(bus_width)] = fl
+
+    @property
+    def rows(self):
+        return self._rows
+
+    @property
+    def cols(self):
+        return self._cols
+
+    @property
+    def height(self):
+        ''' alias for rows'''
+        return self._rows
+
+    @property
+    def width(self):
+        ''' alias for cols'''
+        return self._cols
 
     def __getitem__(self, bus_width):
         return self._layers[bus_width]

--- a/src/fabric/fabric.py
+++ b/src/fabric/fabric.py
@@ -1,6 +1,7 @@
 import lxml.etree as ET
 from util import NamedIDObject
 from .fabricfuns import Side, mapSide, parse_name
+from abc import ABCMeta
 
 
 class Port(NamedIDObject):
@@ -74,8 +75,33 @@ class Track(NamedIDObject):
 #        return '{} --> {}'.format(self._names[0], self._names[1])
 
 
-class FabricLayer:
-    def __init__(self, sources, sinks, routable, tracks):
+class FabricDims(metaclass=ABCMeta):
+    def __init__(self, rows, cols):
+        self._rows = rows
+        self._cols = cols
+
+    @property
+    def rows(self):
+        return self._rows
+
+    @property
+    def cols(self):
+        return self._cols
+
+    @property
+    def height(self):
+        ''' alias for rows'''
+        return self._rows
+
+    @property
+    def width(self):
+        ''' alias for cols'''
+        return self._cols
+
+
+class FabricLayer(FabricDims):
+    def __init__(self, rows, cols, sources, sinks, routable, tracks):
+        super().__init__(rows, cols)
         self._sources = sources
         self._sinks = sinks
         self._routable = routable
@@ -98,35 +124,17 @@ class FabricLayer:
         return self._tracks
 
 
-class Fabric:
+class Fabric(FabricDims):
     def __init__(self, parsed_params):
-        self._rows = parsed_params['rows']
-        self._cols = parsed_params['cols']
+        super().__init__(parsed_params['rows'], parsed_params['cols'])
         self._layers = dict()
         for bus_width in parsed_params['bus_widths']:
-            fl = FabricLayer(parsed_params['sources' + bus_width],
+            fl = FabricLayer(self.rows, self.cols,
+                             parsed_params['sources' + bus_width],
                              parsed_params['sinks' + bus_width],
                              parsed_params['routable' + bus_width],
                              parsed_params['tracks' + bus_width])
             self._layers[int(bus_width)] = fl
-
-    @property
-    def rows(self):
-        return self._rows
-
-    @property
-    def cols(self):
-        return self._cols
-
-    @property
-    def height(self):
-        ''' alias for rows'''
-        return self._rows
-
-    @property
-    def width(self):
-        ''' alias for cols'''
-        return self._cols
 
     def __getitem__(self, bus_width):
         return self._layers[bus_width]

--- a/src/pnr/constraints.py
+++ b/src/pnr/constraints.py
@@ -96,8 +96,8 @@ def excl_constraints(fabric, design, p_state, r_state, vars, solver):
     # TODO: don't hardcode these -- get from coreir?
     ports = {'a', 'b'}
 
-    sources = fabric.sources
-    sinks = fabric.sinks
+    sources = fabric[16].sources
+    sinks = fabric[16].sinks
 
     # for connected modules, make sure it's not connected to wrong inputs
     # TODO: Fix this so doesn't assume only connected to one input port
@@ -166,8 +166,8 @@ def reachability(fabric, design, p_state, r_state, vars, solver):
         Works with build_msgraph, excl_constraints and dist_limit
     '''
     reaches = []
-    sources = fabric.sources
-    sinks = fabric.sinks
+    sources = fabric[16].sources
+    sinks = fabric[16].sinks
     for net in design.nets:
         src = net.src
         dst = net.dst
@@ -214,8 +214,8 @@ def dist_limit(dist_factor):
 
     def dist_constraints(fabric, design, p_state, r_state, vars, solver):
         constraints = []
-        sources = fabric.sources
-        sinks = fabric.sinks
+        sources = fabric[16].sources
+        sinks = fabric[16].sinks
         for net in design.nets:
             src = net.src
             dst = net.dst
@@ -268,8 +268,8 @@ def build_msgraph(fabric, design, p_state, r_state, vars, solver):
 
     graph = solver.graphs[0]  # only one graph in this encoding
 
-    sources = fabric.sources
-    sinks = fabric.sinks
+    sources = fabric[16].sources
+    sinks = fabric[16].sinks
 
     # add msnodes for all the used PEs first (because special naming scheme)
     # Hacky! Hardcoding port names
@@ -280,7 +280,7 @@ def build_msgraph(fabric, design, p_state, r_state, vars, solver):
                 vars[sinks[(x, y, 'b')]] = graph.addNode('({},{})PE_b'.format(x, y))
                 vars[sources[(x, y, 'out')]] = graph.addNode('({},{})PE_out'.format(x, y))
 
-    for track in fabric.tracks:
+    for track in fabric[16].tracks:
         src = track.src
         dst = track.dst
         # naming scheme is (x, y)Side_direction[track]
@@ -314,8 +314,8 @@ def build_net_graphs(fabric, design, p_state, r_state, vars, solver):
         vars[net] = solver.add_graph()
         node_dict[net] = dict()
 
-    sources = fabric.sources
-    sinks = fabric.sinks
+    sources = fabric[16].sources
+    sinks = fabric[16].sinks
 
     # add msnodes for all the used PEs first (because special naming scheme)
     for x in range(fabric.width):
@@ -335,7 +335,7 @@ def build_net_graphs(fabric, design, p_state, r_state, vars, solver):
                 vars[sinks[(x, y, 'b')]] = b
                 vars[sources[(x, y, 'out')]] = out
 
-    for track in fabric.tracks:
+    for track in fabric[16].tracks:
         src = track.src
         dst = track.dst
 

--- a/src/pnr/constraints.py
+++ b/src/pnr/constraints.py
@@ -86,7 +86,7 @@ def pin_IO(fabric, design, state, vars, solver):
 
 #################################### Routing Constraints ################################
 
-def excl_constraints(fabriclayer, design, p_state, r_state, vars, solver):
+def excl_constraints(fabric, design, p_state, r_state, vars, solver, layer=16):
     '''
         Exclusivity constraints for single graph encoding
         Works with build_msgraph, reachability and dist_limit
@@ -96,8 +96,8 @@ def excl_constraints(fabriclayer, design, p_state, r_state, vars, solver):
     # TODO: don't hardcode these -- get from coreir?
     ports = {'a', 'b'}
 
-    sources = fabriclayer.sources
-    sinks = fabriclayer.sinks
+    sources = fabric[layer].sources
+    sinks = fabric[layer].sinks
 
     # for connected modules, make sure it's not connected to wrong inputs
     # TODO: Fix this so doesn't assume only connected to one input port
@@ -160,14 +160,14 @@ def excl_constraints(fabriclayer, design, p_state, r_state, vars, solver):
     return solver.And(c)
 
 
-def reachability(fabriclayer, design, p_state, r_state, vars, solver):
+def reachability(fabric, design, p_state, r_state, vars, solver, layer=16):
     '''
         Enforce reachability for nets in single graph encoding
         Works with build_msgraph, excl_constraints and dist_limit
     '''
     reaches = []
-    sources = fabriclayer.sources
-    sinks = fabriclayer.sinks
+    sources = fabric[layer].sources
+    sinks = fabric[layer].sinks
     for net in design.nets:
         src = net.src
         dst = net.dst
@@ -212,10 +212,10 @@ def dist_limit(dist_factor):
     if not isinstance(dist_factor, int):
         raise ValueError('Expected integer distance factor. Received {}'.format(type(dist_factor)))
 
-    def dist_constraints(fabriclayer, design, p_state, r_state, vars, solver):
+    def dist_constraints(fabric, design, p_state, r_state, vars, solver, layer=16):
         constraints = []
-        sources = fabriclayer.sources
-        sinks = fabriclayer.sinks
+        sources = fabric[layer].sources
+        sinks = fabric[layer].sinks
         for net in design.nets:
             src = net.src
             dst = net.dst
@@ -258,7 +258,7 @@ def dist_limit(dist_factor):
     return dist_constraints
 
 
-def build_msgraph(fabriclayer, design, p_state, r_state, vars, solver):
+def build_msgraph(fabric, design, p_state, r_state, vars, solver, layer=16):
     # to comply with multigraph, add graph for each net
     # note: in this case, all point to the same graph
     # this allows us to reuse constraints such as dist_limit and use the same model_reader
@@ -268,19 +268,19 @@ def build_msgraph(fabriclayer, design, p_state, r_state, vars, solver):
 
     graph = solver.graphs[0]  # only one graph in this encoding
 
-    sources = fabriclayer.sources
-    sinks = fabriclayer.sinks
+    sources = fabric[layer].sources
+    sinks = fabric[layer].sinks
 
     # add msnodes for all the used PEs first (because special naming scheme)
     # Hacky! Hardcoding port names
-    for x in range(fabriclayer.width):
-        for y in range(fabriclayer.height):
+    for x in range(fabric.width):
+        for y in range(fabric.height):
             if (x, y) in p_state.I:
                 vars[sinks[(x, y, 'a')]] = graph.addNode('({},{})PE_a'.format(x, y))
                 vars[sinks[(x, y, 'b')]] = graph.addNode('({},{})PE_b'.format(x, y))
                 vars[sources[(x, y, 'out')]] = graph.addNode('({},{})PE_out'.format(x, y))
 
-    for track in fabriclayer.tracks:
+    for track in fabric[layer].tracks:
         src = track.src
         dst = track.dst
         # naming scheme is (x, y)Side_direction[track]
@@ -296,7 +296,7 @@ def build_msgraph(fabriclayer, design, p_state, r_state, vars, solver):
     return solver.And([])
 
 
-def build_net_graphs(fabriclayer, design, p_state, r_state, vars, solver):
+def build_net_graphs(fabric, design, p_state, r_state, vars, solver, layer=16):
     '''
         An alternative monosat encoding which builds a graph for each net.
         Handles exclusivity constraints inherently
@@ -314,12 +314,12 @@ def build_net_graphs(fabriclayer, design, p_state, r_state, vars, solver):
         vars[net] = solver.add_graph()
         node_dict[net] = dict()
 
-    sources = fabriclayer.sources
-    sinks = fabriclayer.sinks
+    sources = fabric[layer].sources
+    sinks = fabric[layer].sinks
 
     # add msnodes for all the used PEs first (because special naming scheme)
-    for x in range(fabriclayer.width):
-        for y in range(fabriclayer.height):
+    for x in range(fabric.width):
+        for y in range(fabric.height):
             if (x, y) in p_state.I:
                 for net in design.nets:
                     src = net.src
@@ -335,7 +335,7 @@ def build_net_graphs(fabriclayer, design, p_state, r_state, vars, solver):
                 vars[sinks[(x, y, 'b')]] = b
                 vars[sources[(x, y, 'out')]] = out
 
-    for track in fabriclayer.tracks:
+    for track in fabric[layer].tracks:
         src = track.src
         dst = track.dst
 

--- a/src/pnr/model_readers.py
+++ b/src/pnr/model_readers.py
@@ -8,8 +8,8 @@ def place_model_reader(fabric, design, state, vars, solver):
 
 
 def route_model_reader(fabric, design, p_state, r_state, vars, solver):
-    sources = fabric.sources
-    sinks = fabric.sinks
+    sources = fabric[16].sources
+    sinks = fabric[16].sinks
     
     for net in design.nets:
         src = net.src

--- a/src/pnr/pnr.py
+++ b/src/pnr/pnr.py
@@ -53,7 +53,8 @@ class PNR:
     def route_design(self, funcs, model_reader):
         constraints = []
         for f in funcs:
-            c = f(self.fabric, self.design, self._place_state, self._route_state, self._route_vars, self._route_solver)
+            # TODO: Layer is currently hardcoded -- eventually iterate through and possibly use different constraints per layer
+            c = f(self.fabric[16], self.design, self._place_state, self._route_state, self._route_vars, self._route_solver)
             self._route_solver.add(self._route_solver.And(c))
 
         if not self._route_solver.solve():

--- a/src/pnr/pnr.py
+++ b/src/pnr/pnr.py
@@ -54,7 +54,7 @@ class PNR:
         constraints = []
         for f in funcs:
             # TODO: Layer is currently hardcoded -- eventually iterate through and possibly use different constraints per layer
-            c = f(self.fabric[16], self.design, self._place_state, self._route_state, self._route_vars, self._route_solver)
+            c = f(self.fabric, self.design, self._place_state, self._route_state, self._route_vars, self._route_solver, 16)
             self._route_solver.add(self._route_solver.And(c))
 
         if not self._route_solver.solve():


### PR DESCRIPTION
Routing constraints now take a layer as an argument (default is 16).

I chose this as opposed to choosing the layer externally and passing only that layer, because we will eventually need to access all the modules on a given layer. Therefore, it's easiest to have the layer as an explicit argument.