### PR TITLE
Add an extra constraint for the recommended route settings

### DIFF
--- a/run_pnr.py
+++ b/run_pnr.py
@@ -29,8 +29,8 @@ fabric_file = args.fabric
 PLACE_CONSTRAINTS = pnr.distinct, pnr.neighborhood(2), pnr.pin_IO, pnr.pin_resource, pnr.register_colors
 PLACE_RELAXED     = pnr.distinct, pnr.pin_IO, pnr.neighborhood(4), pnr.pin_resource, pnr.register_colors
 
-simultaneous, split_regs, ROUTE_CONSTRAINTS = pnr.reach_and_notreach(1)
-simultaneous, split_regs, ROUTE_RELAXED = pnr.reach_and_notreach(3)
+simultaneous, split_regs, ROUTE_CONSTRAINTS = pnr.recommended_route_settings(relaxed=False)
+simultaneous, split_regs, ROUTE_RELAXED = pnr.recommended_route_settings(relaxed=True)
 
 print("Loading design: {}".format(design_file))
 ce = ConfigEngine()


### PR DESCRIPTION
Because registers are not split in this encoding, we need
to enforce unreachability constraints to some other modules

This is to prevent the following situation:
a --> r1 --> b
|
-->c

without these new constraints, a-->r1-->c would be a potential
Monosat output.

The hope is that only enforcing not-reaches constraints on registers
and the few relevant modules is less expensive than using them for every
pair of unconnected modules.