### PR TITLE
One bit routing support and seeding solvers

### DIFF
--- a/pnrdoctor/design/design.py
+++ b/pnrdoctor/design/design.py
@@ -39,6 +39,12 @@ class Design(NamedIDObject):
         self._modules = frozenset(modules)
         self._ties = frozenset(ties)
 
+        layers = set()
+        for tie in ties:
+            layers.add(tie.width)
+
+        self._layers = frozenset(layers)
+
         # assertions
         for module in self.modules:
             assert module.resource != Resource.UNSET, module
@@ -61,6 +67,10 @@ class Design(NamedIDObject):
     @property
     def ties(self):
         return self._ties
+
+    @property
+    def layers(self):
+        return self._layers
 
     @lru_cache(maxsize=32)
     def modules_with_attr(self, attr):

--- a/pnrdoctor/fabric/fabric.py
+++ b/pnrdoctor/fabric/fabric.py
@@ -143,6 +143,7 @@ class Fabric:
         self._rows = parsed_params['rows']
         self._cols = parsed_params['cols']
         self._num_tracks = min(parsed_params['num_tracks'].values())
+        self._layers = frozenset(parsed_params['layers'])
         self._locations = parsed_params['locations']
         # temporarily limiting register locations
         if Resource.Reg in self._locations:
@@ -154,6 +155,7 @@ class Fabric:
         self._port_names = parsed_params['port_names']
 
         # Hacky hardcoding register port names
+        # because they're not provided by cgra_info
         self._port_names[(Resource.Reg, 16)].sources.add('out')
         self._port_names[(Resource.Reg, 16)].sinks.add('a')
 
@@ -174,6 +176,13 @@ class Fabric:
     def width(self):
         ''' alias for cols'''
         return self._cols
+
+    @property
+    def layers(self):
+        '''
+        Available layers in the parsed fabric
+        '''
+        return self._layers
 
     @property
     def num_tracks(self):

--- a/pnrdoctor/pnr/backends.py
+++ b/pnrdoctor/pnr/backends.py
@@ -257,7 +257,7 @@ def write_bitstream(fabric, bitstream, config_engine, annotate):
             processed_r_state[tindex.snk.ps].add(tindex)
 
         # HACK hardcoded layer
-        for layer in {16}:
+        for layer in {16, 1}:
             for pos in sorted(processed_r_state):
                 tile_addr = config_engine[pos].tile_addr
                 x, y = pos

--- a/pnrdoctor/pnr/backends.py
+++ b/pnrdoctor/pnr/backends.py
@@ -250,30 +250,29 @@ def write_bitstream(fabric, bitstream, config_engine, annotate):
         # Process r_state
         processed_r_state = defaultdict(SetList)
         for k, tindex in r_state.items():
-            if isinstance(k, tuple):
+            if isinstance(k, tuple) and k[1] == 'debug':
                 # this is debug information
                 continue
 
-            processed_r_state[tindex.snk.ps].add(tindex)
+            processed_r_state[(tindex.snk.ps, tindex.bw)].add(tindex)
 
         # HACK hardcoded layer
-        for layer in {16, 1}:
-            for pos in sorted(processed_r_state):
-                tile_addr = config_engine[pos].tile_addr
-                x, y = pos
-                t_indices = processed_r_state[pos]
+        for pos, layer in sorted(processed_r_state):
+            tile_addr = config_engine[pos].tile_addr
+            x, y = pos
+            t_indices = processed_r_state[(pos, layer)]
 
-                data, comment, feature_address = _proc_sb()
-                _write(data, tile_addr, feature_address, bs, comment)
-                if pos in p_state.I:
-                    for mod in p_state.I[pos]:
-                        if mod.resource != Resource.Reg:
-                            for port in fabric.port_names[(mod.resource, layer)].sinks:
-                                data, comment, feature_address = _proc_cb(port)
-                                _write(data, tile_addr, feature_address, bs, comment)
-
-                            data, comment, feature_address = res2fun[mod.resource](mod)
+            data, comment, feature_address = _proc_sb()
+            _write(data, tile_addr, feature_address, bs, comment)
+            if pos in p_state.I:
+                for mod in p_state.I[pos]:
+                    if mod.resource != Resource.Reg:
+                        for port in fabric.port_names[(mod.resource, layer)].sinks:
+                            data, comment, feature_address = _proc_cb(port)
                             _write(data, tile_addr, feature_address, bs, comment)
+
+                        data, comment, feature_address = res2fun[mod.resource](mod)
+                        _write(data, tile_addr, feature_address, bs, comment)
 
 
 def write_debug(design, output=sys.stdout):

--- a/pnrdoctor/pnr/constraints.py
+++ b/pnrdoctor/pnr/constraints.py
@@ -324,8 +324,7 @@ def reg_unreachability(fabric, design, p_state, r_state, vars, solver, layer=16)
         Intended to be used with at_most_one_driver
     '''
 
-    # TODO: change to layer indexing
-    graph = solver.graphs[0]
+    graph = solver.graphs[layer]
     constraints = []
 
     for m in design.modules:

--- a/pnrdoctor/pnr/constraints.py
+++ b/pnrdoctor/pnr/constraints.py
@@ -168,7 +168,7 @@ def _get_nonreg_input(reg):
 
 ################################ Graph Building/Modifying Functions #############################
 def build_msgraph(fabric, design, p_state, r_state, vars, solver, layer=16):
-    graph = solver.add_graph()
+    graph = solver.add_graph(layer)
 
     node_inedges = defaultdict(list)
 
@@ -220,7 +220,7 @@ def build_spnr(region=0):
         # make undirected edges to each location
 
         node_dict = dict()
-        graph = solver.graphs[0]
+        graph = solver.graphs[layer]
 
         # list for holding edge equality constraints
         edge_constraints = list()
@@ -294,7 +294,7 @@ def reachability(fabric, design, p_state, r_state, vars, solver, layer=16):
         Works with build_msgraph, excl_constraints and dist_limit
     '''
     reaches = []
-    graph = solver.graphs[0]
+    graph = solver.graphs[layer]
 
     for tie in design.ties:
         # hacky don't handle wrong layer
@@ -354,7 +354,7 @@ def unreachability(fabric, design, p_state, r_state, vars, solver, layer=16):
         Works with build_msgraph, reachability and dist_limit
     '''
     c = []
-    graph = solver.graphs[0]
+    graph = solver.graphs[layer]
 
     # for connected modules, make sure it's not connected to wrong inputs
     for tie in design.ties:
@@ -411,7 +411,7 @@ def dist_limit(dist_factor, include_reg=False):
 
     def dist_constraints(fabric, design, p_state, r_state, vars, solver, layer=16):
         constraints = []
-        graph = solver.graphs[0]
+        graph = solver.graphs[layer]
 
         for tie in design.ties:
             # hacky don't handle wrong layer

--- a/pnrdoctor/pnr/constraints.py
+++ b/pnrdoctor/pnr/constraints.py
@@ -167,43 +167,44 @@ def _get_nonreg_input(reg):
 
 
 ################################ Graph Building/Modifying Functions #############################
-def build_msgraph(fabric, design, p_state, r_state, vars, solver, layer=16):
-    graph = solver.add_graph(layer)
+def build_msgraph(fabric, design, p_state, r_state, vars, solver):
+    for layer in design.layers:
+        graph = solver.add_graph(layer)
 
-    node_inedges = defaultdict(list)
+        node_inedges = defaultdict(list)
 
-    # add nodes for modules
-    for mod in design.modules:
-        for _type in {'sources', 'sinks'}:
-            for port_name in getattr(fabric.port_names[(mod.resource, layer)], _type):
-                index = get_muxindex(mod, p_state, layer, port_name)
-                p = getattr(fabric[index], _type[:-1])  # source/sink instead of sources/sinks
-                vars[p] = graph.addNode(p.name)
-                vars[(mod, port_name)] = vars[p]
+        # add nodes for modules
+        for mod in design.modules:
+            for _type in {'sources', 'sinks'}:
+                for port_name in getattr(fabric.port_names[(mod.resource, layer)], _type):
+                    index = get_muxindex(mod, p_state, layer, port_name)
+                    p = getattr(fabric[index], _type[:-1])  # source/sink instead of sources/sinks
+                    vars[p] = graph.addNode(p.name)
+                    vars[(mod, port_name)] = vars[p]
 
-    tindex = trackindex(src=STAR, snk=STAR, bw=layer)
-    for track in fabric[tindex]:
-        src = track.src
-        dst = track.dst
-        # naming scheme is (x, y)Side_direction[track]
-        # checking port resources
+        tindex = trackindex(src=STAR, snk=STAR, bw=layer)
+        for track in fabric[tindex]:
+            src = track.src
+            dst = track.dst
+            # naming scheme is (x, y)Side_direction[track]
+            # checking port resources
 
-        if src not in vars:
-            vars[src] = graph.addNode(src.name)
-        if dst not in vars:
-            vars[dst] = graph.addNode(dst.name)
+            if src not in vars:
+                vars[src] = graph.addNode(src.name)
+            if dst not in vars:
+                vars[dst] = graph.addNode(dst.name)
 
-        # create a monosat edge
-        e = graph.addEdge(vars[src], vars[dst])
+            # create a monosat edge
+            e = graph.addEdge(vars[src], vars[dst])
 
-        node_inedges[vars[dst]].append(e)
+            node_inedges[vars[dst]].append(e)
 
-        vars[e] = track  # we need to recover the track in model_reader
+            vars[e] = track  # we need to recover the track in model_reader
 
-    # save the node in edges for later use
-    # it's cleaner to have this constraint in a separate  function
-    node_inedges = map(lambda l: tuple(l), node_inedges.values())  # make hashable
-    vars['node_inedges'] = frozenset(node_inedges)
+        # save the node in edges for later use
+        # it's cleaner to have this constraint in a separate  function
+        node_inedges = map(lambda l: tuple(l), node_inedges.values())  # make hashable
+        vars['node_inedges'] = frozenset(node_inedges)
 
     return solver.And([])
 
@@ -211,76 +212,77 @@ def build_msgraph(fabric, design, p_state, r_state, vars, solver, layer=16):
 def build_spnr(region=0):
     # the region specifies how far from the original placement monosat can choose
     # TODO: support region != 0 in bitstream writer
-    def _build_spnr(fabric, design, p_state, r_state, vars, solver, layer=16):
+    def _build_spnr(fabric, design, p_state, r_state, vars, solver):
         '''
            Modifies an existing monosat graph to allow monosat to 'replace' components
            within a region around the original placement
         '''
-        # For each port of each module, create an external node
-        # make undirected edges to each location
+        for layer in design.layers:
 
-        node_dict = dict()
-        graph = solver.graphs[layer]
+            # For each port of each module, create an external node
+            # make undirected edges to each location
+            node_dict = dict()
+            graph = solver.graphs[layer]
 
-        # list for holding edge equality constraints
-        edge_constraints = list()
+            # list for holding edge equality constraints
+            edge_constraints = list()
 
-        # add virtual nodes for modules
-        for mod in design.modules:
-            if mod.resource != Resource.Reg:
-                for _type in {'sources', 'sinks'}:
-                    for port_name in getattr(fabric.port_names[(mod.resource, layer)], _type):
-                        n = graph.addNode('{}_{}'.format(mod.name, port_name))
-                        vars[(mod, port_name)] = n
-                        node_dict[n] = list()
-            else:
-                # registers are not split
-                # i.e. both port names point to same node
-                regnode = graph.addNode(mod.name)
-                vars[mod] = regnode  # have one index just for mod
-                node_dict[regnode] = list()
-                for _type in {'sources', 'sinks'}:
-                    for port_name in getattr(fabric.port_names[(mod.resource, layer)], _type):
-                        vars[(mod, port_name)] = regnode  # convenient to also index the same as other modules
-
-            # take intersection with possible locations
-            # register locations include the track, so remove track using map
-            for loc in _resource_region(p_state[mod][0], 0) & set(map(lambda x: x[:2], fabric.locations[mod.resource])):
+            # add virtual nodes for modules
+            for mod in design.modules:
                 if mod.resource != Resource.Reg:
-                    eqedges = list()
                     for _type in {'sources', 'sinks'}:
                         for port_name in getattr(fabric.port_names[(mod.resource, layer)], _type):
-                            mindex = muxindex(resource=mod.resource, ps=loc, bw=layer, port=port_name)
-                            e = graph.addUndirectedEdge(vars[(mod, port_name)],
-                                                        vars[getattr(fabric[mindex], _type[:-1])])
-                                                        # source/sink instead of sources/sinks
-                            eqedges.append(e)
-                            node_dict[vars[(mod, port_name)]].append(e)
-
-                    # assert that a placement places all ports of a given module in the same location
-                    for e1, e2 in zip(eqedges, eqedges[1:]):
-                        edge_constraints.append(solver.Eq(e1, e2))
-
+                            n = graph.addNode('{}_{}'.format(mod.name, port_name))
+                            vars[(mod, port_name)] = n
+                            node_dict[n] = list()
                 else:
-                    # this is a register
+                    # registers are not split
+                    # i.e. both port names point to same node
+                    regnode = graph.addNode(mod.name)
+                    vars[mod] = regnode  # have one index just for mod
+                    node_dict[regnode] = list()
+                    for _type in {'sources', 'sinks'}:
+                        for port_name in getattr(fabric.port_names[(mod.resource, layer)], _type):
+                            vars[(mod, port_name)] = regnode  # convenient to also index the same as other modules
 
-                    # get all of the switch box muxes at the current location
-                    mindices_pattern = muxindex(resource=Resource.SB, ps=loc,
-                                                po=STAR, bw=layer, track=STAR)
+                # take intersection with possible locations
+                # register locations include the track, so remove track using map
+                for loc in _resource_region(p_state[mod][0], 0) & set(map(lambda x: x[:2], fabric.locations[mod.resource])):
+                    if mod.resource != Resource.Reg:
+                        eqedges = list()
+                        for _type in {'sources', 'sinks'}:
+                            for port_name in getattr(fabric.port_names[(mod.resource, layer)], _type):
+                                mindex = muxindex(resource=mod.resource, ps=loc, bw=layer, port=port_name)
+                                e = graph.addUndirectedEdge(vars[(mod, port_name)],
+                                                            vars[getattr(fabric[mindex], _type[:-1])])
+                                                            # source/sink instead of sources/sinks
+                                eqedges.append(e)
+                                node_dict[vars[(mod, port_name)]].append(e)
 
-                    # take only the ones with registers
-                    mindices = set(fabric.matching_keys(mindices_pattern)) & fabric.muxindex_locations[Resource.Reg]
+                        # assert that a placement places all ports of a given module in the same location
+                        for e1, e2 in zip(eqedges, eqedges[1:]):
+                            edge_constraints.append(solver.Eq(e1, e2))
 
-                    for mindex in mindices:
-                        assert fabric[mindex].source == fabric[mindex].sink, \
-                          'Cannot split registers and use build_spnr'
-                        e = graph.addUndirectedEdge(vars[mod],
-                                                    vars[fabric[mindex].source])
-                        node_dict[vars[mod]].append(e)
+                    else:
+                        # this is a register
 
-        # assert that modules are only placed in one location
-        for n, edges in node_dict.items():
-            solver.AtMostOne(edges)
+                        # get all of the switch box muxes at the current location
+                        mindices_pattern = muxindex(resource=Resource.SB, ps=loc,
+                                                    po=STAR, bw=layer, track=STAR)
+
+                        # take only the ones with registers
+                        mindices = set(fabric.matching_keys(mindices_pattern)) & fabric.muxindex_locations[Resource.Reg]
+
+                        for mindex in mindices:
+                            assert fabric[mindex].source == fabric[mindex].sink, \
+                              'Cannot split registers and use build_spnr'
+                            e = graph.addUndirectedEdge(vars[mod],
+                                                        vars[fabric[mindex].source])
+                            node_dict[vars[mod]].append(e)
+
+            # assert that modules are only placed in one location
+            for n, edges in node_dict.items():
+                solver.AtMostOne(edges)
 
         return solver.And(edge_constraints)
     return _build_spnr
@@ -288,19 +290,15 @@ def build_spnr(region=0):
 
 ################################ Reachability Constraints #################################
 
-def reachability(fabric, design, p_state, r_state, vars, solver, layer=16):
+def reachability(fabric, design, p_state, r_state, vars, solver):
     '''
         Enforce reachability for ties in single graph encoding
         Works with build_msgraph, excl_constraints and dist_limit
     '''
     reaches = []
-    graph = solver.graphs[layer]
 
     for tie in design.ties:
-        # hacky don't handle wrong layer
-        if tie.width != layer:
-            continue
-
+        graph = solver.graphs[tie.width]
         reaches.append(graph.reaches(vars[(tie.src, tie.src_port)],
                                      vars[(tie.dst, tie.dst_port)]))
 
@@ -309,7 +307,7 @@ def reachability(fabric, design, p_state, r_state, vars, solver, layer=16):
 
 ############################## Exclusivity Constraints #########################
 
-def at_most_one_driver(fabric, design, p_state, r_state, vars, solver, layer=16):
+def at_most_one_driver(fabric, design, p_state, r_state, vars, solver):
     # assert that each node acting as a dst has at most one driver
     for inedges in vars['node_inedges']:  # 'node_inedges' maps to a frozenset of lists of edges
         if len(inedges) > 1:
@@ -318,49 +316,51 @@ def at_most_one_driver(fabric, design, p_state, r_state, vars, solver, layer=16)
     return solver.And([])
 
 
-def reg_unreachability(fabric, design, p_state, r_state, vars, solver, layer=16):
+def reg_unreachability(fabric, design, p_state, r_state, vars, solver):
     '''
         Enforce unreachability constraints when register is a source.
         Intended to be used with at_most_one_driver
     '''
 
-    graph = solver.graphs[layer]
-    constraints = []
+    for layer in design.layers:
 
-    for m in design.modules:
-        if m.resource == Resource.Reg:
+        graph = solver.graphs[layer]
+        constraints = []
 
-            # get the first non register in the input path
-            input_m = _get_nonreg_input(m)
-            # get the outputs of the registers input
-            input_m_outputs = {t for t in input_m.outputs.values()}
+        for m in design.modules:
+            if m.resource == Resource.Reg:
 
-            for outport in fabric.port_names[(Resource.Reg, layer)].sources:
-                for tie in input_m_outputs:
-                    if tie.dst == m:
-                        # ignore tie to itself
-                        continue
+                # get the first non register in the input path
+                input_m = _get_nonreg_input(m)
+                # get the outputs of the registers input
+                input_m_outputs = {t for t in input_m.outputs.values()}
 
-                    constraints.append(~graph.reaches(vars[(m, outport)],
-                                                      vars[tie.dst, tie.dst_port]))
+                for outport in fabric.port_names[(Resource.Reg, layer)].sources:
+                    for tie in input_m_outputs:
+                        if tie.dst == m:
+                            # ignore tie to itself
+                            continue
+
+                        constraints.append(~graph.reaches(vars[(m, outport)],
+                                                          vars[tie.dst, tie.dst_port]))
 
     return solver.And(constraints)
 
 
-def unreachability(fabric, design, p_state, r_state, vars, solver, layer=16):
+def unreachability(fabric, design, p_state, r_state, vars, solver):
     '''
         Exclusivity constraints for single graph encoding
         Works with build_msgraph, reachability and dist_limit
     '''
     c = []
-    graph = solver.graphs[layer]
 
     # for connected modules, make sure it's not connected to wrong inputs
     for tie in design.ties:
         # hacky don't handle wrong layer here
         # and if destination is a register, it only has one port
         # so it doesn't need exclusivity constraints
-        if tie.width != layer or tie.dst.resource == Resource.Reg:
+        graph = solver.graphs[tie.width]
+        if tie.dst.resource == Resource.Reg:
             continue
 
         src = tie.src
@@ -408,15 +408,12 @@ def dist_limit(dist_factor, include_reg=False):
     if not isinstance(dist_factor, int):
         raise ValueError('Expected integer distance factor. Received {}'.format(type(dist_factor)))
 
-    def dist_constraints(fabric, design, p_state, r_state, vars, solver, layer=16):
+    def dist_constraints(fabric, design, p_state, r_state, vars, solver):
         constraints = []
-        graph = solver.graphs[layer]
 
         for tie in design.ties:
-            # hacky don't handle wrong layer
-            if tie.width != layer:
-                continue
-
+            layer = tie.width
+            graph = solver.graphs[layer]
             src = tie.src
             dst = tie.dst
 

--- a/pnrdoctor/pnr/frontends.py
+++ b/pnrdoctor/pnr/frontends.py
@@ -81,6 +81,9 @@ def _scan_ports(root, params):
     port_names = defaultdict(port_names_container)
     params['port_names'] = port_names
 
+    # keep track of available layers
+    params['layers'] = set()
+
     rows = 0
     cols = 0
 
@@ -112,6 +115,7 @@ def _scan_ports(root, params):
 
     def _scan_cb(cb):
         _bw = int(cb.get('bus').replace('BUS', ''))
+        params['layers'].add(_bw)
         _ps = (x, y)
         for mux in cb.findall('mux'):
             _port = mux.get('snk')

--- a/pnrdoctor/pnr/model_readers.py
+++ b/pnrdoctor/pnr/model_readers.py
@@ -18,7 +18,6 @@ def route_model_reader(simultaneous=False):
 
         processed_mods = set()
 
-        # TODO: set up design views so can iterate by layer
         for tie in design.ties:
             graph = solver.graphs[tie.width]
 

--- a/pnrdoctor/pnr/model_readers.py
+++ b/pnrdoctor/pnr/model_readers.py
@@ -16,37 +16,34 @@ def route_model_reader(simultaneous=False):
         # make sure there are never two drivers of the same port
         invariant_check = dict()
 
-        # hardcoded layers right now
-        graph = solver.graphs[0]
-        for layer in {16}:
-            for tie in design.ties:
-                # hacky handle only one layer at a time
-                # note: won't actually need this here when
-                # routing one bit signals
+        # TODO: set up design views so can iterate by layer
+        for tie in design.ties:
+            graph = solver.graphs[tie.width]
 
-                src_node = vars[(tie.src, tie.src_port)]
-                dst_node = vars[(tie.dst, tie.dst_port)]
-                reaches = graph.reaches(src_node, dst_node)
-                l = graph.getPath(reaches)
-                path = tuple(graph.names[node] for node in l)
-                # record for debug printing
-                r_state[(tie, 'debug')] = path
+            src_node = vars[(tie.src, tie.src_port)]
+            dst_node = vars[(tie.dst, tie.dst_port)]
+            reaches = graph.reaches(src_node, dst_node)
+            l = graph.getPath(reaches)
+            assert l is not None, tie
+            path = tuple(graph.names[node] for node in l)
+            # record for debug printing
+            r_state[(tie, 'debug')] = path
 
-                # when simultaneous, the edges on the end are virtual
-                if simultaneous:
-                    l = l[1:-1]
+            # when simultaneous, the edges on the end are virtual
+            if simultaneous:
+                l = l[1:-1]
 
-                for n1, n2 in zip(l, l[1:]):
-                    edge = graph.getEdge(n1, n2)
-                    track = vars[edge]
+            for n1, n2 in zip(l, l[1:]):
+                edge = graph.getEdge(n1, n2)
+                track = vars[edge]
 
-                    if track in invariant_check:
-                        assert tie.src == invariant_check[track.dst], '{} driven by {} and {}'.format(track.dst, invariant_check[track.dst], tie.src)
+                if track in invariant_check:
+                    assert tie.src == invariant_check[track.dst], '{} driven by {} and {}'.format(track.dst, invariant_check[track.dst], tie.src)
 
-                    invariant_check[track.dst] = tie.src
+                invariant_check[track.dst] = tie.src
 
-                    dst = track.dst
+                dst = track.dst
 
-                    r_state[tie] = trackindex(snk=dst.index, src=track.src.index, bw=layer)
+                r_state[tie] = trackindex(snk=dst.index, src=track.src.index, bw=tie.width)
 
     return _route_model_reader

--- a/pnrdoctor/pnr/pnr.py
+++ b/pnrdoctor/pnr/pnr.py
@@ -11,6 +11,9 @@ class PNR:
         self._fabric = fabric
         self._design = design
 
+        assert design.layers <= fabric.layers, \
+          "The layers in the design should be a subset of the layers available in the fabric."
+
         self._place_state = BiMultiDict()
         self._route_state = BiMultiDict()
 
@@ -59,11 +62,9 @@ class PNR:
 
     def route_design(self, funcs, model_reader):
         constraints = []
-        # hacky hardcoding layers
-        for layer in {1, 16}:
-            for f in funcs:
-                c = f(self.fabric, self.design, self._place_state, self._route_state, self._route_vars, self._route_solver, layer)
-                self._route_solver.add(self._route_solver.And(c))
+        for f in funcs:
+            c = f(self.fabric, self.design, self._place_state, self._route_state, self._route_vars, self._route_solver)
+            self._route_solver.add(self._route_solver.And(c))
 
         if not self._route_solver.solve():
             self._route_solver.reset()

--- a/pnrdoctor/pnr/pnr.py
+++ b/pnrdoctor/pnr/pnr.py
@@ -7,7 +7,7 @@ from pnrdoctor.util import BiMultiDict, BiDict
 
 ''' Class for handling place & route '''
 class PNR:
-    def __init__(self, fabric, design, solver_str):
+    def __init__(self, fabric, design, solver_str, seed=1):
         self._fabric = fabric
         self._design = design
 
@@ -22,6 +22,9 @@ class PNR:
 
         # set options
         self._place_solver.SetOption('produce-models', 'true')
+        self._place_solver.SetOption('random-seed', seed)
+        self._place_solver.SetLogic('QF_BV')
+        self._route_solver.set_option('random-seed', seed)
 
     def pin_module(self, module, placement):
         self._place_state[module] = placement
@@ -36,9 +39,10 @@ class PNR:
             self._place_solver.Assert(c)
 
         if not self._place_solver.CheckSat():
-            self._place_solver.reset()
+            self._place_solver.Reset()
             # set options
             self._place_solver.SetOption('produce-models', 'true')
+            self._place_solver.SetLogic('QF_BV')
             self._place_vars = BiDict()
             return False
 

--- a/pnrdoctor/pnr/pnr.py
+++ b/pnrdoctor/pnr/pnr.py
@@ -24,6 +24,12 @@ class PNR:
         self._place_solver.SetOption('produce-models', 'true')
         self._place_solver.SetOption('random-seed', seed)
         self._place_solver.SetLogic('QF_BV')
+
+        # use best settings per solver
+        if solver_str == 'CVC4':
+            self._place_solver.SetOption('bitblast', 'eager')
+            self._place_solver.SetOption('bv-sat-solver', 'cryptominisat')
+
         self._route_solver.set_option('random-seed', seed)
 
     def pin_module(self, module, placement):

--- a/pnrdoctor/pnr/pnr.py
+++ b/pnrdoctor/pnr/pnr.py
@@ -53,9 +53,9 @@ class PNR:
 
     def route_design(self, funcs, model_reader):
         constraints = []
-        for f in funcs:
-            # hacky hardcoding layers
-            for layer in {16}:
+        # hacky hardcoding layers
+        for layer in {1, 16}:
+            for f in funcs:
                 c = f(self.fabric, self.design, self._place_state, self._route_state, self._route_vars, self._route_solver, layer)
                 self._route_solver.add(self._route_solver.And(c))
 

--- a/pnrdoctor/smt/solvers.py
+++ b/pnrdoctor/smt/solvers.py
@@ -58,7 +58,9 @@ class Solver_monosat(Solver_base):
     def __init__(self):
         super().__init__()
         ms.Monosat().init('-decide-theories -route')
-        self.graphs = []
+        # dictionary to graphs with arbitrary index
+        # often layer --> graph
+        self.graphs = dict()
         self.at_most_one_builtin_size = 10
 
     def solve(self):
@@ -66,14 +68,14 @@ class Solver_monosat(Solver_base):
         self.sat = ms.Solve()
         return self.sat
 
-    def add_graph(self):
+    def add_graph(self, layer):
         g = ms.Graph()
-        self.graphs.append(g)
+        self.graphs[layer] = g
         return g
 
     def reset(self):
         super().reset()
-        self.graphs = []
+        self.graphs = dict()
         ms.Monosat().init('-decide-theories -route')
 
     def set_option(self, opt, val):

--- a/pnrdoctor/smt/solvers.py
+++ b/pnrdoctor/smt/solvers.py
@@ -2,6 +2,7 @@ from abc import ABCMeta, abstractmethod
 import z3
 import monosat as ms
 import itertools
+import random
 
 
 class Solver_base(metaclass=ABCMeta):
@@ -74,6 +75,12 @@ class Solver_monosat(Solver_base):
         super().reset()
         self.graphs = []
         ms.Monosat().init('-decide-theories -route')
+
+    def set_option(self, opt, val):
+        if opt == 'random-seed':
+            random.seed(val)
+        else:
+            raise ValueError('{} is not yet a supported option'.format(opt))
 
     def get_model(self):
         if self.sat:

--- a/run_pnr.py
+++ b/run_pnr.py
@@ -19,12 +19,13 @@ parser.add_argument('--bitstream', metavar='<BITSTREAM_FILE>', help='output CGRA
 parser.add_argument('--annotate', metavar='<ANNOTATED_FILE>', help='output bitstream with annotations')
 parser.add_argument('--noroute', action='store_true')
 parser.add_argument('--solver', help='choose the smt solver to use for placement', default='Z3')
+parser.add_argument('--seed', help='Seed the randomness in solvers', default=1)
 
 args = parser.parse_args()
 
 design_file = args.design
 fabric_file = args.fabric
-
+seed = args.seed
 
 PLACE_CONSTRAINTS = pnr.distinct, pnr.neighborhood(2), pnr.pin_IO, pnr.pin_resource, pnr.register_colors
 PLACE_RELAXED     = pnr.distinct, pnr.pin_IO, pnr.neighborhood(4), pnr.pin_resource, pnr.register_colors
@@ -45,7 +46,7 @@ iterations = 0
 
 while not pnrdone and iterations < 10:
     fab = pnr.parse_xml(fabric_file, ce)
-    p = pnr.PNR(fab, des, args.solver)
+    p = pnr.PNR(fab, des, args.solver, seed)
     POSITION_T = partial(smt.BVXY, solver=p._place_solver)
     print("Placing design...", end=' ')
     sys.stdout.flush()

--- a/run_pnr.py
+++ b/run_pnr.py
@@ -18,7 +18,7 @@ parser.add_argument('--print-route', action='store_true', dest='print_route', he
 parser.add_argument('--bitstream', metavar='<BITSTREAM_FILE>', help='output CGRA configuration in bitstream')
 parser.add_argument('--annotate', metavar='<ANNOTATED_FILE>', help='output bitstream with annotations')
 parser.add_argument('--noroute', action='store_true')
-parser.add_argument('--solver', help='choose the smt solver to use for placement', default='Z3')
+parser.add_argument('--solver', help='choose the smt solver to use for placement', default='CVC4')
 parser.add_argument('--seed', help='Seed the randomness in solvers', default=1)
 
 args = parser.parse_args()


### PR DESCRIPTION
Seeds solvers to help improve reproducibility. Note: this is not a 100% guarantee. Z3 for example sets the seed for the SAT solver but not theory decisions.

Adds one-bit routing support and fixes bitstream writer for the one-bit signals. This hasn't been thoroughly tested, because I only have a toy one-bit example.

This also sets the default solver to be CVC4 with the best settings.

Note, to run with these changes locally, you will need the latest version of smt-switch, z3 and a patched version of CVC4 (which should be integrated soon).