### PR TITLE
`BitVector.unsigned_value` -> `BitVector.as_uint()`

### DIFF
--- a/pnrdoctor/design/core2graph.py
+++ b/pnrdoctor/design/core2graph.py
@@ -30,14 +30,14 @@ def load_core(file, *libs):
 
             if op_kind in ('alu', 'combined'):
                 modules[inst_name]['layer'] |= Layer.Data
-                modules[inst_name]['conf']['alu_op']       = inst.config['alu_op'].value.unsigned_value
+                modules[inst_name]['conf']['alu_op']       = inst.config['alu_op'].value.as_uint()
                 modules[inst_name]['conf']['alu_op_debug'] = inst.config['alu_op_debug'].value
-                modules[inst_name]['conf']['signed']       = inst.config['signed'].value.unsigned_value
+                modules[inst_name]['conf']['signed']       = inst.config['signed'].value.as_uint()
 
             if op_kind in ('bit', 'combined'):
                 modules[inst_name]['layer'] |= Layer.Bit
-                modules[inst_name]['conf']['lut_value'] = inst.config['lut_value'].value.unsigned_value
-                modules[inst_name]['conf']['flag_sel']  = inst.config['flag_sel'].value.unsigned_value
+                modules[inst_name]['conf']['lut_value'] = inst.config['lut_value'].value.as_uint()
+                modules[inst_name]['conf']['flag_sel']  = inst.config['flag_sel'].value.as_uint()
 
             if op_kind not in ('bit', 'alu', 'combined'):
                 raise ValueError("Unkown op_kind `{}' in `{}' expected <`bit', `alu', `combined'>".format(file, op_kind))
@@ -69,7 +69,7 @@ def load_core(file, *libs):
             modules[inst_name]['type']  = 'Const'
             modules[inst_name]['res']   = Resource.Fused # always fuse constants
             modules[inst_name]['layer'] = Layer.Data
-            modules[inst_name]['conf']  = inst.config['value'].value.unsigned_value
+            modules[inst_name]['conf']  = inst.config['value'].value.as_uint()
         elif namespace == 'corebit' and inst_type == 'const':
             modules[inst_name]['type']  = 'Const'
             modules[inst_name]['res']   = Resource.Fused # always fuse constants


### PR DESCRIPTION
Update for upstream API change in bit_vector

See https://travis-ci.org/StanfordAHA/CGRAFlow/builds/416459457 for CGRAFlow build using this branch